### PR TITLE
PY-11317 Incorrect type detection for formatter string with java String

### DIFF
--- a/__builtin__.py
+++ b/__builtin__.py
@@ -1232,7 +1232,7 @@ class str(basestring):
 
         :rtype: string
         """
-        return b''
+        return ''
 
     def __rmul__(self, n):
         """n shallow copies of x concatenated.
@@ -1615,7 +1615,7 @@ class unicode(basestring):
 
         :rtype: unicode
         """
-        return ''
+        return u''
 
     def __rmul__(self, n):
         """n shallow copies of x concatenated.

--- a/__builtin__.py
+++ b/__builtin__.py
@@ -1230,7 +1230,7 @@ class str(basestring):
     def __mod__(self, y):
         """x % y.
 
-        :rtype: string
+        :rtype: str
         """
         return ''
 


### PR DESCRIPTION
Fix return type for formatting operation:

str = "test %s " % str

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jetbrains/python-skeletons/1)

<!-- Reviewable:end -->
