### PR TITLE
Update os.symlink skeleton to Python 3.4

### DIFF
--- a/os/__init__.py
+++ b/os/__init__.py
@@ -898,11 +898,13 @@ def statvfs(path):
     pass
 
 
-def symlink(source, link_name):
+def symlink(source, link_name, target_is_directory=False, dir_fd=None):
     """Create a symbolic link pointing to source named link_name.
 
     :type source: bytes | unicode
     :type link_name: bytes| unicode
+    :type target_is_directory: bool
+    :type dir_fd: int | None
     :rtype: None
     """
     pass


### PR DESCRIPTION
This is a pretty trivial change - I'm using os.symlink and it's annoying in PyCharm when it complains about my using the `target_is_directory` argument.

It looks like there are a few inconsistencies between the Python 3.4 docs for `os` and the skeletons but I don't have time right now to fix them. Official docs here: https://docs.python.org/3.4/library/os.html#os.symlink

Note that I don't know how to represent the signature:

``` python
os.symlink(source, link_name, target_is_directory=False, *, dir_fd=None)
```

and keep Python 2 compatibility so I represented:

``` python
os.symlink(source, link_name, target_is_directory=False, dir_fd=None)
```

instead.
