### PR TITLE
Add skeleton for alembic.

### DIFF
--- a/alembic.py
+++ b/alembic.py
@@ -1,0 +1,6 @@
+from alembic.operations import Operations
+from alembic.environment import EnvironmentContext
+
+op = Operations()
+context = EnvironmentContext()
+


### PR DESCRIPTION
Alembic already has reStructuredText documentation, but has some magic when it comes to importing methods so that PyCharm and IntelliJ Idea can not find methods. This is small script that makes alembic functions visible to IDE.