### PR TITLE
Fix misspelling of "children" in multiprocessing skeleton

### DIFF
--- a/multiprocessing/__init__.py
+++ b/multiprocessing/__init__.py
@@ -136,7 +136,7 @@ class JoinableQueue(multiprocessing.Queue):
         pass
 
 
-def active_childern():
+def active_children():
     """
     :rtype: list[multiprocessing.Process]
     """


### PR DESCRIPTION
Just as the title says. The skeleton currently leads to the incorrect suggestion of `active_childern` for what is actually the multiprocessing `active_children` function.