### PR TITLE
Adding missing keywords for pytest.mark.xfail.

### DIFF
--- a/pytest/__init__.py
+++ b/pytest/__init__.py
@@ -85,7 +85,7 @@ class mark:
         """
 
     @staticmethod
-    def xfail(condition=None, reason=None, run=True):
+    def xfail(condition=None, reason=None, raises=None, run=True, strict=False):
         """mark the the test function as an expected failure if eval(condition)
         has a True value.
         


### PR DESCRIPTION
I found that the skeleton included with PyCharm 2016.1.4 was missing these keyword arguments, vs http://pytest.org/latest/skipping.html#xfail-signature-summary.