### PR TITLE
Modify the return type of the File seek functions.

### DIFF
--- a/StringIO.py
+++ b/StringIO.py
@@ -86,11 +86,12 @@ class StringIO(object):
         pass
 
     def seek(self, offset, whence=0):
-        """Set the buffer's current position, like stdio's fseek().
+        """Set the buffer's current position, like stdio's fseek() except
+        that return the new absolute position.
 
         :type offset: numbers.Integral
         :type whence: numbers.Integral
-        :rtype: None
+        :rtype: int
         """
         pass
 

--- a/__builtin__.py
+++ b/__builtin__.py
@@ -2776,11 +2776,12 @@ class file(object):
         return []
 
     def seek(self, offset, whence=0):
-        """Set the file's current position, like stdio's fseek().
+        """Set the file's current position, like stdio's fseek() except
+        that return the new absolute position.
 
         :type offset: numbers.Integral
         :type whence: numbers.Integral
-        :rtype: None
+        :rtype: int
         """
         pass
 

--- a/io.py
+++ b/io.py
@@ -99,10 +99,11 @@ class IOBase(object):
 
     def seek(self, offset, whence=io.SEEK_SET):
         """Change the stream position to the given byte offset.
+        Return the new absolute position.
 
         :type offset: numbers.Integral
         :type whence: numbers.Integral
-        :rtype: None
+        :rtype: int
         """
         pass
 
@@ -304,10 +305,11 @@ class FileIO(io.RawIOBase):
 
     def seek(self, offset, whence=io.SEEK_SET):
         """Change the stream position to the given byte offset.
+        Return the new absolute position.
 
         :type offset: numbers.Integral
         :type whence: numbers.Integral
-        :rtype: None
+        :rtype: int
         """
         pass
 
@@ -549,10 +551,11 @@ class TextIOWrapper(io.TextIOBase):
 
     def seek(self, offset, whence=io.SEEK_SET):
         """Change the stream position to the given byte offset.
+        Return the new absolute position.
 
         :type offset: numbers.Integral
         :type whence: numbers.Integral
-        :rtype: None
+        :rtype: int
         """
         pass
 

--- a/os/__init__.py
+++ b/os/__init__.py
@@ -493,11 +493,12 @@ def isatty(fd):
 def lseek(fd, pos, how):
     """Set the current position of file descriptor fd to position pos, modified
     by how.
+    Return the new absolute position.
 
     :type fd: int
     :type pos: numbers.Integral
     :type how: int
-    :rtype: None
+    :rtype: int
     """
     pass
 


### PR DESCRIPTION
According to python documentation:
https://docs.python.org/3/library/io.html?highlight=seek#io.IOBase.seek
https://docs.python.org/3/library/io.html?highlight=seek#io.TextIOBase.seek
https://docs.python.org/3/library/os.html?highlight=seek#os.lseek

The seek function returns the new absolute position in the file.
This is different to the fseek function, that returns 0 upon successful completion.

For lseek the documentation does not specify the return type, although it
behaves in the same way.
