### PR TITLE
Add 'iterable' arg to defaultdict signature.

### DIFF
--- a/collections.py
+++ b/collections.py
@@ -41,9 +41,10 @@ class Iterator(collections.Iterable):
 
 
 class defaultdict(dict):
-    def __init__(self, default_factory=None, **kwargs):
+    def __init__(self, default_factory=None, iterable=None, **kwargs):
         """
         :type default_factory: () -> V
+        :type iterable: collections.Iterable[(T, V)]
         :rtype: defaultdict[Any, V]
         """
         pass


### PR DESCRIPTION
As with the signature of `dict`, a single iterator can be provided outside of named kwargs.
Without this `collections.defaultdict(int, my_iter)` warns about an "unexpected argument".