### PR TITLE
docs: Fix a few typos

### DIFF
--- a/py/path/__init__.py
+++ b/py/path/__init__.py
@@ -496,7 +496,7 @@ class SvnWCCommandPath(PathBase):
 
     def blame(self):
         """ return a list of tuples of three elements:
-            (revision, commiter, line)
+            (revision, committer, line)
         """
 
     def commit(self, msg='', rec=1):

--- a/pytest/__init__.py
+++ b/pytest/__init__.py
@@ -297,7 +297,7 @@ skip.Exception = Exception
 
 
 def fail(msg="", pytrace=True):
-    """ explicitely fail an currently-executing test with the given Message.
+    """ explicitly fail an currently-executing test with the given Message.
 
     :arg pytrace: if false the msg represents the full failure information
                   and no python traceback will be reported.


### PR DESCRIPTION
There are small typos in:
- py/path/__init__.py
- pytest/__init__.py

Fixes:
- Should read `explicitly` rather than `explicitely`.
- Should read `committer` rather than `commiter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md